### PR TITLE
Custom area chart curves

### DIFF
--- a/src/components/CustomAreaChart.vue
+++ b/src/components/CustomAreaChart.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from "vue";
 import { scaleLinear, scaleBand, scaleOrdinal } from "d3-scale";
-import { min, max } from "d3-array";
 import { format } from "d3-format";
 import { timeFormat, timeParse } from "d3-time-format";
 import {
@@ -61,7 +60,6 @@ const props = defineProps({
 
 const width = ref(500);
 const hoveredDate = ref(null);
-const hoveredPoint = ref(null);
 const tooltipData = ref([]);
 
 const containerMargins = computed(() => ({
@@ -229,7 +227,6 @@ const colorScale = computed(() =>
 
 const handleMouseMove = (e) => {
   const xPosition = e.offsetX - marginLeft;
-  const yPosition = e.offsetY - marginTop;
 
   if (datesWithData.value.length > 0) {
     hoveredDate.value = datesWithData.value.reduce((prev, curr) => {

--- a/src/components/CustomAreaChart.vue
+++ b/src/components/CustomAreaChart.vue
@@ -4,7 +4,15 @@ import { scaleLinear, scaleBand, scaleOrdinal } from "d3-scale";
 import { min, max } from "d3-array";
 import { format } from "d3-format";
 import { timeFormat, timeParse } from "d3-time-format";
-import { stack, area, curveBundle } from "d3-shape";
+import {
+  stack,
+  area,
+  curveBasis,
+  curveCardinal,
+  curveLinear,
+  curveMonotoneX,
+  curveNatural,
+} from "d3-shape";
 import {
   createDateArray,
   findWeekEnd,
@@ -45,6 +53,10 @@ const props = defineProps({
 
   // Scale props
   xScale: { type: Function, default: null },
+
+  // Interpolation curve used for the area chart.
+  // Accepted values: 'basis', 'cardinal', 'linear', 'monotoneX' or 'natural'
+  curveType: { type: String, default: "monotoneX" },
 });
 
 const width = ref(500);
@@ -58,6 +70,14 @@ const containerMargins = computed(() => ({
   marginBottom: props.containerMarginBottom + "px",
   marginLeft: props.containerMarginLeft + "px",
 }));
+
+const CURVE_MAP = {
+  basis: curveBasis,
+  cardinal: curveCardinal,
+  linear: curveLinear,
+  monotoneX: curveMonotoneX,
+  natural: curveNatural,
+};
 
 onMounted(() => {
   window.addEventListener("resize", handleResize);
@@ -189,6 +209,8 @@ const yTicks = computed(() => {
   return yScale.ticks(numberOfYTicks);
 });
 
+const resolvedCurve = computed(() => CURVE_MAP[props.curveType] ?? curveMonotoneX);
+
 const areaGenerator = computed(() =>
   area()
     .x((d) => {
@@ -196,7 +218,7 @@ const areaGenerator = computed(() =>
     })
     .y1((d) => yScale(d[1]))
     .y0((d) => yScale(d[0]))
-    .curve(curveBundle.beta(1))
+    .curve(resolvedCurve.value)
 );
 
 const colors = computed(() => selectAccessibleColorPalette(uniqueLabels.value));

--- a/tests/visual/components/TestCustomAreaChart.vue
+++ b/tests/visual/components/TestCustomAreaChart.vue
@@ -1,12 +1,16 @@
 <template>
   <div class="test-container">
     <h1>Custom Area Chart Component Test</h1>
-    <CustomAreaChart 
-      :aggregatedData="mockData" 
-      :firstWeek="firstWeek" 
-      :lastWeek="lastWeek"
-      :areaChartRange="areaChartRange"
-    />
+    <template v-for="curveType in curveTypes" :key="curveType">
+      <h2>Curve type: {{ curveType }}</h2>
+      <CustomAreaChart
+        :aggregatedData="mockData"
+        :firstWeek="firstWeek"
+        :lastWeek="lastWeek"
+        :areaChartRange="areaChartRange"
+        :curveType="curveType"
+      />
+    </template>
   </div>
 </template>
 
@@ -17,6 +21,8 @@ import CustomAreaChart from "../../../src/components/CustomAreaChart.vue";
 const firstWeek = 202515;
 const lastWeek = 202532;
 const areaChartRange = 120;
+
+const curveTypes = ["basis", "cardinal", "linear", "monotoneX", "natural"];
 
 const mockData = ref([
   {


### PR DESCRIPTION
# Summary

This PR creates a curveType prop that allows five types of interpolation curves to be selected: basis, cardinal, linear, monotoneX or natural. Please refer to https://d3js.org/d3-shape/curve for further information.